### PR TITLE
feat: add time cutoff for daily notes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "telegram-inbox",
 	"name": "Telegram Inbox",
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"minAppVersion": "1.5.11",
 	"description": "Receive messages from Telegram bot and add them to daily note.",
 	"author": "icealtria",

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ const DEFAULT_SETTINGS: TGInboxSettings = {
   reverse_order: false,
   remove_formatting: false,
   run_after_sync: true,
+  daily_note_time_cutoff: "00:00",
 };
 
 export default class TGInbox extends Plugin {

--- a/src/utils/diary.ts
+++ b/src/utils/diary.ts
@@ -4,10 +4,9 @@ import {
   getAllDailyNotes,
   getDailyNote,
 } from "obsidian-daily-notes-interface";
+import type { TGInboxSettings } from "../settings";
 
-
-async function createDiary() {
-  const date = moment();
+async function createDiary(date: moment.Moment) {
   return await createDailyNote(date);
 }
 
@@ -19,7 +18,7 @@ export async function getTodayDiary() {
 
     if (!dailyNote) {
       console.log('Daily note not found, creating new one');
-      dailyNote = await createDiary();
+      dailyNote = await createDiary(date);
     }
 
     return dailyNote;
@@ -27,4 +26,41 @@ export async function getTodayDiary() {
     console.error(`Error retrieving or creating today's diary: ${error}`);
     throw error;
   }
+}
+
+export async function getDiaryWithTimeCutoff(settings: TGInboxSettings, messageDate?: moment.Moment) {
+  try {
+    const date = messageDate || moment();
+    const adjustedDate = getAdjustedDateForTimeCutoff(date, settings.daily_note_time_cutoff);
+    
+    const dailyNotes = getAllDailyNotes();
+    let dailyNote = getDailyNote(adjustedDate, dailyNotes);
+
+    if (!dailyNote) {
+      console.log('Daily note not found, creating new one');
+      dailyNote = await createDiary(adjustedDate);
+    }
+
+    return dailyNote;
+  } catch (error) {
+    console.error(`Error retrieving or creating diary with time cutoff: ${error}`);
+    throw error;
+  }
+}
+
+function getAdjustedDateForTimeCutoff(messageDate: moment.Moment, timeCutoff: string): moment.Moment {
+  // Parse the time cutoff (format: "HH:MM")
+  const [cutoffHour, cutoffMinute] = timeCutoff.split(':').map(Number);
+  
+  // Get the message time (only time part)
+  const messageHour = messageDate.hour();
+  const messageMinute = messageDate.minute();
+  
+  // If message time is before the cutoff time, use previous day
+  if (messageHour < cutoffHour || (messageHour === cutoffHour && messageMinute < cutoffMinute)) {
+    return moment(messageDate).subtract(1, 'day');
+  }
+  
+  // Otherwise, use the same day
+  return moment(messageDate);
 }

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,9 +1,10 @@
 import type { File } from "grammy/types";
 import type { TGInboxSettings } from "src/settings";
-import { getTodayDiary } from "./diary";
+import { getTodayDiary, getDiaryWithTimeCutoff } from "./diary";
 import { type TFile, normalizePath, type Vault } from "obsidian";
 import { generatePath } from "./template";
 import type { MessageUpdate } from "src/type";
+import { moment } from "obsidian";
 
 export function getExt(path: string) {
     return path.split(".").pop();
@@ -38,6 +39,13 @@ export async function getSavePath(
             }
             return file;
         }
+        
+        // Use time cutoff logic for daily notes
+        if (msg) {
+            const messageDate = moment(msg.date * 1000);
+            return await getDiaryWithTimeCutoff(settings, messageDate);
+        }
+        
         return getTodayDiary();
     } catch (error) {
         console.error(`Error in getSavedPath: ${error}`);

--- a/styles.css
+++ b/styles.css
@@ -25,3 +25,14 @@ If your plugin does not need CSS, delete this file.
 .tg-inbox-setting-disabled>.setting-item-info * {
   color: var(--text-faint);
 }
+
+.tg-inbox-error-text {
+  color: #ff6b6b;
+  font-size: 0.8em;
+  margin-top: 4px;
+}
+
+.tg-inbox-time-input-error {
+  border-color: #ff6b6b !important;
+  box-shadow: 0 0 0 1px #ff6b6b !important;
+}


### PR DESCRIPTION
Hi again! Thanks for creating and maintaining this plugin — I’ve been using it regularly, and it’s been a huge help in organizing my Telegram messages inside Obsidian.

However, one issue I’ve repeatedly encountered is that messages sent around **midnight or early morning** (e.g. 1–3 AM) are always saved under the *next day’s* daily note. To address this, I implemented a **time cutoff** feature that lets users define when a “day” should roll over. 

I'm still getting used to plugin development, so I would really appreciate any code reviews and feedback.

### Summary of Changes

#### 1. New Setting Option

* Added a new setting: `daily_note_time_cutoff` (default: `"00:00"`)
* Visible only when **“Save to custom path”** is disabled
* Accepts **HH:MM format** (00:00–23:59) with real-time input validation

#### 2. Time-Based Date Calculation

* If a message’s timestamp is *before* the cutoff → it’s stored in the **previous day’s** note
* If it’s *after* or *equal to* the cutoff → it’s stored in the **current day’s** note
* Example: with a cutoff at `05:00`, a message sent at `03:13` will be saved under the **previous day**

#### 3. UI/UX Improvements

* Invalid input now highlights the field in red
* Added an English validation message:
  `"Invalid time format. Please use HH:MM format (00:00–23:59)."`
* Added CSS styling for error states

#### 4. Modified Files

* `src/settings.ts`: added setting interface and input field
* `src/main.ts`: added default setting value
* `src/utils/diary.ts`: implemented cutoff-based date logic
* `src/utils/file.ts`: adjusted file path selection logic
* `styles.css`: added styling for invalid input