### PR TITLE
feat: improve inbox reliability, timezone handling, and env-based dev…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and customize the value.
+# Use the absolute path to your Obsidian dev vault.
+TELEGRAM_INBOX_DEV_VAULT=/Users/your-user/Documents/Obsidian/My-Vault-Dev

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,17 @@ main.js
 # obsidian
 data.json
 
+# local environment settings
+.env
+.env.*
+!.env.example
+
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store
+
+# Exclude package locks
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+bun.lockb
+bun.lock

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This plugin can receive messages from Telegram bots and add them to Obsidian's d
 4. Add your username or telegram id to `Allowed Users`. You can get your id from [@Get_UIDbot](https://t.me/Get_UIDbot)
 5. Click the `Restart` button.
 
-> When the plugin is not running, messages will be stored on the Telegram server for 24 hours at most. [source](https://core.telegram.org/bots/api#getting-updates)
+> When the plugin is not running, messages will be stored on the Telegram server for 24 hours at most. [source](https://core.telegram.org/bots/api#getting-updates:~:text=Incoming%20updates%20are%20stored%20on%20the%20server%20until%20the%20bot%20receives%20them%20either%20way%2C%20but%20they%20will%20not%20be%20kept%20longer%20than%2024%20hours.)
 
 ## Manually install the plugin
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -p tsconfig.build.json -noEmit -skipLibCheck && node esbuild.config.mjs production",
+		"deploy:dev": "npm run build && node scripts/deploy-plugin.mjs",
 		"version": "node version-bump.mjs && git add manifest.json versions.json",
 		"lint": "oxlint src",
 		"test": "node --test --require tsx/cjs --require ./test/register-obsidian.cjs \"test/**/*.spec.ts\""

--- a/scripts/deploy-plugin.mjs
+++ b/scripts/deploy-plugin.mjs
@@ -1,0 +1,88 @@
+import { cpSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const PLUGIN_ID = "telegram-inbox";
+const ARTIFACTS = ["main.js", "manifest.json", "styles.css"];
+const ENV_FILE = ".env";
+const VAULT_ENV_KEY = "TELEGRAM_INBOX_DEV_VAULT";
+
+/**
+ * Loads basic KEY=VALUE pairs from a local .env file.
+ * This parser is intentionally minimal and sufficient for vault-path config.
+ */
+function loadEnvFile() {
+  const envPath = resolve(process.cwd(), ENV_FILE);
+  if (!existsSync(envPath)) {
+    return {};
+  }
+
+  const raw = readFileSync(envPath, "utf-8");
+  const parsed = {};
+
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const separatorIndex = trimmed.indexOf("=");
+    if (separatorIndex <= 0) {
+      continue;
+    }
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    const value = trimmed.slice(separatorIndex + 1).trim();
+    parsed[key] = value;
+  }
+
+  return parsed;
+}
+
+/**
+ * Resolves destination vault from `.env` first, then process env as fallback.
+ */
+function resolveVaultPath() {
+  const envFileVars = loadEnvFile();
+  const fromEnvFile = envFileVars[VAULT_ENV_KEY]?.trim();
+  if (fromEnvFile) {
+    return fromEnvFile;
+  }
+  return process.env[VAULT_ENV_KEY]?.trim();
+}
+
+function assertVaultPath(vaultPath) {
+  if (!vaultPath) {
+    throw new Error(
+      `Vault path is missing. Set ${VAULT_ENV_KEY} in ${ENV_FILE}.`
+    );
+  }
+
+  if (!existsSync(vaultPath)) {
+    throw new Error(`Vault path does not exist: ${vaultPath}`);
+  }
+}
+
+function copyArtifacts(destinationDir) {
+  mkdirSync(destinationDir, { recursive: true });
+
+  for (const artifact of ARTIFACTS) {
+    const sourcePath = resolve(process.cwd(), artifact);
+    if (!existsSync(sourcePath)) {
+      throw new Error(`Missing artifact: ${artifact}. Run npm run build first.`);
+    }
+    cpSync(sourcePath, join(destinationDir, artifact));
+  }
+}
+
+function main() {
+  const vaultPath = resolveVaultPath();
+  assertVaultPath(vaultPath);
+
+  const destinationDir = join(vaultPath, ".obsidian", "plugins", PLUGIN_ID);
+  copyArtifacts(destinationDir);
+
+  // Keep this concise for command-line usage.
+  console.log(`Deployed ${PLUGIN_ID} to: ${destinationDir}`);
+}
+
+main();

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -7,6 +7,7 @@ import {
 } from "./bot/middleware";
 import { VaultWriter } from "./bot/vault-writer";
 import { setupCommands, setupMessageHandlers } from "./bot/handlers";
+import { RuntimeStateStore } from "./state";
 
 const DEFAULT_OFFSET = 1;
 
@@ -16,10 +17,12 @@ export class TelegramBot {
   settings: TGInboxSettings;
   update_id = 0;
   private vaultWriter: VaultWriter;
+  private runtimeStateStore: RuntimeStateStore;
 
-  constructor(vault: Vault, settings: TGInboxSettings) {
+  constructor(vault: Vault, settings: TGInboxSettings, runtimeStateStore: RuntimeStateStore) {
     this.vault = vault;
     this.settings = settings;
+    this.runtimeStateStore = runtimeStateStore;
     this.vaultWriter = new VaultWriter(vault, settings);
     this.bot = new Bot(settings.token);
 
@@ -42,8 +45,8 @@ export class TelegramBot {
   }
 
   private setupHandlers(): void {
-    setupCommands(this.bot, this.settings, this.vaultWriter);
-    setupMessageHandlers(this.bot, this.settings, this.vaultWriter);
+    setupCommands(this.bot, this.settings, this.vaultWriter, this.runtimeStateStore);
+    setupMessageHandlers(this.bot, this.settings, this.vaultWriter, this.runtimeStateStore);
   }
 
   private setupErrorHandling(): void {
@@ -58,7 +61,9 @@ export class TelegramBot {
 
   async getUpdates(): Promise<void> {
     try {
-      const offset = this.update_id ? this.update_id + 1 : DEFAULT_OFFSET;
+      const persistedUpdateId = this.runtimeStateStore.getLastProcessedUpdateId();
+      const latestKnownUpdateId = Math.max(this.update_id, persistedUpdateId);
+      const offset = latestKnownUpdateId ? latestKnownUpdateId + 1 : DEFAULT_OFFSET;
       const updates = await this.bot.api.getUpdates({ offset });
 
       for (const update of updates) {
@@ -76,5 +81,32 @@ export class TelegramBot {
       console.error("Error getting updates:", error);
       throw error;
     }
+  }
+
+  /**
+   * Processes retry queue entries that are due.
+   * Returns number of items attempted in this pass.
+   */
+  async retryFailedQueue(): Promise<number> {
+    const pending = this.runtimeStateStore.getReadyRetries();
+
+    for (const item of pending) {
+      try {
+        await this.vaultWriter.insertMessageToVault(item.content, item.msg);
+        await this.runtimeStateStore.markProcessed(item.message_key, item.update_id);
+      } catch (error) {
+        await this.runtimeStateStore.markRetryAttemptFailure(
+          item.id,
+          (error as Error).message
+        );
+      }
+    }
+
+    return pending.length;
+  }
+
+  /** Returns current retry queue size for status/reporting. */
+  getRetryQueueSize(): number {
+    return this.runtimeStateStore.getRetryQueueSize();
   }
 }

--- a/src/bot/handlers.ts
+++ b/src/bot/handlers.ts
@@ -6,8 +6,19 @@ import { getFileUrl } from "../utils/file";
 import type { VaultWriter } from "./vault-writer";
 import { generateFilename } from "./utils";
 import type { MessageUpdate } from "../type";
+import { RuntimeStateStore } from "../state";
 
+type SupportedMediaType = "voice" | "audio" | "photo" | "video" | "document" | "other";
+
+/**
+ * Applies post-processing acknowledgement behavior after successful ingestion.
+ * Falls back from delete to reaction when bot permissions are insufficient.
+ */
 async function executePostAction(ctx: Context, settings: TGInboxSettings): Promise<void> {
+  if (settings.action_after_reception === "quiet") {
+    return;
+  }
+
   if (settings.action_after_reception === "delete") {
     try {
       await ctx.deleteMessage();
@@ -29,7 +40,88 @@ function handleVaultError(ctx: Context, err: Error, context: string): void {
   ctx.reply(`Failed to ${context}. Error: ${err.message}`);
 }
 
-export function setupCommands(bot: Bot, settings: TGInboxSettings, vaultWriter: VaultWriter) {
+/** Detects a normalized media type from Telegram message payload fields. */
+function getMediaType(msg: MessageUpdate): SupportedMediaType {
+  if ("voice" in msg && msg.voice) {
+    return "voice";
+  }
+  if ("audio" in msg && msg.audio) {
+    return "audio";
+  }
+  if ("photo" in msg && msg.photo) {
+    return "photo";
+  }
+  if ("video" in msg && msg.video) {
+    return "video";
+  }
+  if ("document" in msg && msg.document) {
+    return "document";
+  }
+  return "other";
+}
+
+/** Resolves whether a media payload should be processed by current filters. */
+function isMediaEnabled(settings: TGInboxSettings, mediaType: SupportedMediaType): boolean {
+  switch (mediaType) {
+    case "voice":
+      return settings.media_filter_voice;
+    case "audio":
+      return settings.media_filter_audio;
+    case "photo":
+      return settings.media_filter_photo;
+    case "video":
+      return settings.media_filter_video;
+    case "document":
+      return settings.media_filter_document;
+    case "other":
+    default:
+      return true;
+  }
+}
+
+/** Persists dedupe bookkeeping after successful processing. */
+async function persistProcessedMessage(
+  runtimeStateStore: RuntimeStateStore,
+  msg: MessageUpdate,
+  updateId?: number
+): Promise<void> {
+  const messageKey = runtimeStateStore.buildMessageKey(msg);
+  await runtimeStateStore.markProcessed(messageKey, updateId);
+}
+
+/** Enqueues failed writes for later retry with persistent metadata. */
+async function queueRetry(
+  runtimeStateStore: RuntimeStateStore,
+  msg: MessageUpdate,
+  content: string,
+  updateId: number | undefined,
+  error: Error
+): Promise<void> {
+  const messageKey = runtimeStateStore.buildMessageKey(msg);
+  await runtimeStateStore.enqueueRetry({
+    messageKey,
+    updateId,
+    msg,
+    content,
+    error: error.message,
+  });
+}
+
+/** True when the message key already exists in persistent dedupe state. */
+function shouldSkipAlreadyProcessed(
+  runtimeStateStore: RuntimeStateStore,
+  msg: MessageUpdate
+): boolean {
+  const messageKey = runtimeStateStore.buildMessageKey(msg);
+  return runtimeStateStore.hasProcessed(messageKey);
+}
+
+export function setupCommands(
+  bot: Bot,
+  settings: TGInboxSettings,
+  vaultWriter: VaultWriter,
+  runtimeStateStore: RuntimeStateStore
+) {
   bot.command("start", (ctx) => {
     ctx.reply(
       "Hello! Send me a message to add it to your Obsidian daily note.\n\n/task followed by the description will add it as a task item."
@@ -37,63 +129,111 @@ export function setupCommands(bot: Bot, settings: TGInboxSettings, vaultWriter: 
   });
 
   bot.command("task", async (ctx) => {
+    const msg = ctx.msg as MessageUpdate;
+    if (shouldSkipAlreadyProcessed(runtimeStateStore, msg)) {
+      await persistProcessedMessage(runtimeStateStore, msg, ctx.update?.update_id);
+      return;
+    }
     const task = `- [ ] ${ctx.match}`;
     try {
-      await vaultWriter.insertMessageToVault(task, ctx.msg as MessageUpdate);
+      await vaultWriter.insertMessageToVault(task, msg);
+      await persistProcessedMessage(runtimeStateStore, msg, ctx.update?.update_id);
       await executePostAction(ctx, settings);
     } catch (err) {
+      await queueRetry(
+        runtimeStateStore,
+        msg,
+        task,
+        ctx.update?.update_id,
+        err as Error
+      );
       handleVaultError(ctx, err as Error, "insert task");
     }
   });
 }
 
-export function setupMessageHandlers(bot: Bot, settings: TGInboxSettings, vaultWriter: VaultWriter) {
+export function setupMessageHandlers(
+  bot: Bot,
+  settings: TGInboxSettings,
+  vaultWriter: VaultWriter,
+  runtimeStateStore: RuntimeStateStore
+) {
   bot.on(["message:text", "channel_post:text"], async (ctx) => {
     const msg = ctx.msg as MessageUpdate;
+    if (shouldSkipAlreadyProcessed(runtimeStateStore, msg)) {
+      await persistProcessedMessage(runtimeStateStore, msg, ctx.update?.update_id);
+      return;
+    }
     const content = generateContentFromTemplate(msg, settings);
 
     try {
       await vaultWriter.insertMessageToVault(content, msg);
+      await persistProcessedMessage(runtimeStateStore, msg, ctx.update?.update_id);
       await executePostAction(ctx, settings);
     } catch (err) {
+      await queueRetry(
+        runtimeStateStore,
+        msg,
+        content,
+        ctx.update?.update_id,
+        err as Error
+      );
       handleVaultError(ctx, err as Error, "insert text message to vault");
     }
   });
 
   bot.on(["message:media", "channel_post:media"], async (ctx) => {
     const msg = ctx.msg as MessageUpdate;
-    let content = generateContentFromTemplate(msg, settings);
-
-    if (settings.download_media) {
-      const file = await ctx.getFile();
-      const filename_ext = generateFilename(msg, file);
-      const url = getFileUrl(file, bot.token);
-
-      console.debug(`Attempting to download media: ${filename_ext} from ${url}`);
-      const downloadResult = await downloadAndSaveFile(
-        vaultWriter.getVault(),
-        url,
-        filename_ext,
-        settings.download_dir
-      );
-
-      if (downloadResult) {
-        content = `![[${filename_ext}]]\n${content}`;
-      } else {
-        console.error(`Failed to download media. File: ${filename_ext}, URL: ${url}`);
-        ctx.reply(`Failed to download media. File: ${filename_ext}, URL: ${url}`);
-      }
+    if (shouldSkipAlreadyProcessed(runtimeStateStore, msg)) {
+      await persistProcessedMessage(runtimeStateStore, msg, ctx.update?.update_id);
+      return;
     }
-
-    if (!settings.download_media && content.length === 0) {
-      console.debug("No content to insert. Skipping.");
+    const mediaType = getMediaType(msg);
+    if (!isMediaEnabled(settings, mediaType)) {
+      console.debug(`Skipping media type '${mediaType}' due to filter setting.`);
       return;
     }
 
+    let content = generateContentFromTemplate(msg, settings);
+
     try {
+      if (settings.download_media) {
+        const file = await ctx.getFile();
+        const filename_ext = generateFilename(msg, file);
+        const url = getFileUrl(file, bot.token);
+
+        console.debug(`Attempting to download media: ${filename_ext} from ${url}`);
+        const downloadResult = await downloadAndSaveFile(
+          vaultWriter.getVault(),
+          url,
+          filename_ext,
+          settings.download_dir
+        );
+
+        if (downloadResult) {
+          content = `![[${filename_ext}]]\n${content}`;
+        } else {
+          console.error(`Failed to download media. File: ${filename_ext}, URL: ${url}`);
+          ctx.reply(`Failed to download media. File: ${filename_ext}, URL: ${url}`);
+        }
+      }
+
+      if (!settings.download_media && content.length === 0) {
+        console.debug("No content to insert. Skipping.");
+        return;
+      }
+
       await vaultWriter.insertMessageToVault(content, msg);
+      await persistProcessedMessage(runtimeStateStore, msg, ctx.update?.update_id);
       await executePostAction(ctx, settings);
     } catch (err) {
+      await queueRetry(
+        runtimeStateStore,
+        msg,
+        content,
+        ctx.update?.update_id,
+        err as Error
+      );
       handleVaultError(ctx, err as Error, "insert media message to vault");
     }
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,19 +3,35 @@ import { TelegramBot } from "./bot";
 import { type TGInboxSettings, DEFAULT_SETTINGS } from "./settings/types";
 import { TGInboxSettingTab } from "./settings";
 import { runAfterSync } from "./utils/sync";
+import {
+  DEFAULT_RUNTIME_STATE,
+  type TGInboxRuntimeState,
+  RuntimeStateStore,
+} from "./state";
+
+interface PluginPersistedData {
+  settings: TGInboxSettings;
+  runtime_state: TGInboxRuntimeState;
+}
 
 export default class TGInbox extends Plugin {
   settings: TGInboxSettings;
   bot: TelegramBot | null;
+  runtimeState: TGInboxRuntimeState;
+  runtimeStateStore: RuntimeStateStore;
   botInfo: {
     username: string;
     isConnected: boolean;
   };
 
   async onload() {
+    await this.loadSettings();
+    this.runtimeStateStore = new RuntimeStateStore(
+      this.runtimeState,
+      async () => this.savePluginData()
+    );
     this.addSettingTab(new TGInboxSettingTab(this.app, this));
     this.addCommands();
-    await this.loadSettings();
 
     if (this.settings.disable_auto_reception) {
       this.addRibbonIcon("send", "Telegram Inbox: Get Updates", () => {
@@ -50,6 +66,28 @@ export default class TGInbox extends Plugin {
       name: "Stop Telegram Bot",
       callback: () => this.stopBot(),
     });
+
+    this.addCommand({
+      id: "tg-inbox-retry-failed-queue",
+      name: "Retry Failed Queue Items",
+      callback: async () => {
+        if (!this.bot) {
+          new Notice("Telegram bot is not running");
+          return;
+        }
+        const retriedCount = await this.bot.retryFailedQueue();
+        new Notice(`Retry queue processed: ${retriedCount} item(s) attempted`);
+      },
+    });
+
+    this.addCommand({
+      id: "tg-inbox-clear-failed-queue",
+      name: "Clear Failed Queue Items",
+      callback: async () => {
+        await this.runtimeStateStore.clearRetryQueue();
+        new Notice("Failed queue cleared");
+      },
+    });
   }
 
   async getBotInfo() {
@@ -65,11 +103,21 @@ export default class TGInbox extends Plugin {
   }
 
   async loadSettings() {
-    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+    const rawData = await this.loadData();
+    const parsedData = this.parsePersistedData(rawData);
+    this.settings = parsedData.settings;
+    this.runtimeState = parsedData.runtime_state;
   }
 
   async saveSettings() {
-    await this.saveData(this.settings);
+    await this.savePluginData();
+  }
+
+  async savePluginData() {
+    await this.saveData({
+      settings: this.settings,
+      runtime_state: this.runtimeState,
+    } satisfies PluginPersistedData);
   }
 
   async initBot() {
@@ -79,7 +127,7 @@ export default class TGInbox extends Plugin {
         return;
       }
       await this.stopBot();
-      this.bot = new TelegramBot(this.app.vault, this.settings);
+      this.bot = new TelegramBot(this.app.vault, this.settings, this.runtimeStateStore);
       if (!this.settings.disable_auto_reception) {
         this.startBot();
       }
@@ -93,6 +141,10 @@ export default class TGInbox extends Plugin {
   async startBot() {
     new Notice("Telegram bot starting");
     if (this.bot) {
+      const retryQueueSize = this.bot.getRetryQueueSize();
+      if (retryQueueSize > 0) {
+        await this.bot.retryFailedQueue();
+      }
       this.bot.start();
     }
   }
@@ -107,5 +159,43 @@ export default class TGInbox extends Plugin {
     } catch (error) {
       console.error("Error stopping bot:", error);
     }
+  }
+
+  private parsePersistedData(rawData: unknown): PluginPersistedData {
+    // Backward compatibility: older versions stored only settings at root level.
+    const isModernData =
+      typeof rawData === "object" &&
+      rawData !== null &&
+      "settings" in rawData &&
+      "runtime_state" in rawData;
+
+    if (isModernData) {
+      const modernData = rawData as Partial<PluginPersistedData>;
+      const runtimeState = Object.assign(
+        {},
+        DEFAULT_RUNTIME_STATE,
+        modernData.runtime_state ?? {}
+      );
+      return {
+        settings: Object.assign({}, DEFAULT_SETTINGS, modernData.settings ?? {}),
+        runtime_state: {
+          last_processed_update_id:
+            typeof runtimeState.last_processed_update_id === "number"
+              ? runtimeState.last_processed_update_id
+              : 0,
+          processed_message_keys: Array.isArray(runtimeState.processed_message_keys)
+            ? runtimeState.processed_message_keys
+            : [],
+          retry_queue: Array.isArray(runtimeState.retry_queue)
+            ? runtimeState.retry_queue
+            : [],
+        },
+      };
+    }
+
+    return {
+      settings: Object.assign({}, DEFAULT_SETTINGS, rawData ?? {}),
+      runtime_state: Object.assign({}, DEFAULT_RUNTIME_STATE),
+    };
   }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,7 +1,7 @@
 import { type App, PluginSettingTab, Setting } from "obsidian";
 import type TGInbox from "./main";
 import * as Mustache from 'mustache';
-import { ActionAfterReception } from "./settings/types";
+import type { ActionAfterReception } from "./settings/types";
 import { getSyncStatus, hasSyncPlugin } from "./utils/sync";
 
 export class TGInboxSettingTab extends PluginSettingTab {
@@ -85,6 +85,60 @@ export class TGInboxSettingTab extends PluginSettingTab {
           })
       );
 
+    new Setting(containerEl)
+      .setName("Media filters")
+      .setHeading();
+
+    new Setting(containerEl)
+      .setName("Voice notes")
+      .setDesc("Receive Telegram voice notes.")
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.media_filter_voice).onChange(async (value) => {
+          this.plugin.settings.media_filter_voice = value;
+          await this.plugin.saveSettings();
+        })
+      );
+
+    new Setting(containerEl)
+      .setName("Audio files")
+      .setDesc("Receive Telegram audio files.")
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.media_filter_audio).onChange(async (value) => {
+          this.plugin.settings.media_filter_audio = value;
+          await this.plugin.saveSettings();
+        })
+      );
+
+    new Setting(containerEl)
+      .setName("Photos")
+      .setDesc("Receive Telegram photos.")
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.media_filter_photo).onChange(async (value) => {
+          this.plugin.settings.media_filter_photo = value;
+          await this.plugin.saveSettings();
+        })
+      );
+
+    new Setting(containerEl)
+      .setName("Videos")
+      .setDesc("Receive Telegram videos.")
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.media_filter_video).onChange(async (value) => {
+          this.plugin.settings.media_filter_video = value;
+          await this.plugin.saveSettings();
+        })
+      );
+
+    new Setting(containerEl)
+      .setName("Documents")
+      .setDesc("Receive Telegram documents.")
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.media_filter_document).onChange(async (value) => {
+          this.plugin.settings.media_filter_document = value;
+          await this.plugin.saveSettings();
+        })
+      );
+
     const downloadDirContainer = containerEl.createDiv({
       cls: "tg-inbox-setting-collapsible"
     });
@@ -147,6 +201,7 @@ export class TGInboxSettingTab extends PluginSettingTab {
         dropdown
           .addOption("react", "React with ❤")
           .addOption("delete", "Delete message")
+          .addOption("quiet", "Do nothing (quiet mode)")
           .setValue(this.plugin.settings.action_after_reception)
           .onChange(async (value: ActionAfterReception) => {
             this.plugin.settings.action_after_reception = value;
@@ -297,6 +352,17 @@ export class TGInboxSettingTab extends PluginSettingTab {
           });
       });
 
+    const timezoneSetting = new Setting(timeCutoffContainer)
+      .setName("Daily note timezone")
+      .setDesc("IANA timezone used for daily note cutoff (e.g. Europe/Paris). Leave empty to use system timezone.")
+      .addText((text) => {
+        text.setPlaceholder("System timezone")
+          .setValue(this.plugin.settings.daily_note_timezone)
+          .onChange((value) => {
+            this.validateAndSetTimezone(value, text.inputEl, timezoneSetting);
+          });
+      });
+
 
     const runAfterSyncSetting = new Setting(containerEl)
       .setName("Run after vault synced")
@@ -405,6 +471,28 @@ export class TGInboxSettingTab extends PluginSettingTab {
     const existingError = setting.descEl.querySelector(".tg-inbox-error-text");
     if (existingError) {
       existingError.remove();
+    }
+  }
+
+  private validateAndSetTimezone(value: string, inputEl: HTMLInputElement, setting: Setting) {
+    const timezone = value.trim();
+    if (!timezone) {
+      inputEl.classList.remove("tg-inbox-time-input-error");
+      this.removeErrorText(setting);
+      this.plugin.settings.daily_note_timezone = "";
+      this.plugin.saveSettings();
+      return;
+    }
+
+    try {
+      new Intl.DateTimeFormat(undefined, { timeZone: timezone });
+      inputEl.classList.remove("tg-inbox-time-input-error");
+      this.removeErrorText(setting);
+      this.plugin.settings.daily_note_timezone = timezone;
+      this.plugin.saveSettings();
+    } catch {
+      inputEl.classList.add("tg-inbox-time-input-error");
+      this.showErrorText(setting, "Invalid timezone. Use IANA format like Europe/Paris.");
     }
   }
 }

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -1,4 +1,4 @@
-export type ActionAfterReception = "react" | "delete";
+export type ActionAfterReception = "react" | "delete" | "quiet";
 
 export interface TGInboxSettings {
   token: string;
@@ -6,6 +6,11 @@ export interface TGInboxSettings {
   allow_users: string[];
   download_dir: string;
   download_media: boolean;
+  media_filter_voice: boolean;
+  media_filter_audio: boolean;
+  media_filter_photo: boolean;
+  media_filter_video: boolean;
+  media_filter_document: boolean;
   message_template: string;
   markdown_escaper: boolean;
   is_custom_file: boolean;
@@ -15,6 +20,7 @@ export interface TGInboxSettings {
   remove_formatting: boolean;
   run_after_sync: boolean;
   daily_note_time_cutoff: string; // Format: "HH:MM" (24-hour format)
+  daily_note_timezone: string; // IANA timezone, empty means system timezone
   insert_after_heading: boolean;
   target_heading: string;
   action_after_reception: ActionAfterReception;
@@ -26,6 +32,11 @@ export const DEFAULT_SETTINGS: TGInboxSettings = {
   allow_users: [],
   download_dir: "/assets",
   download_media: false,
+  media_filter_voice: true,
+  media_filter_audio: true,
+  media_filter_photo: true,
+  media_filter_video: true,
+  media_filter_document: true,
   markdown_escaper: false,
   message_template: "{{{text}}}",
   is_custom_file: false,
@@ -35,6 +46,7 @@ export const DEFAULT_SETTINGS: TGInboxSettings = {
   remove_formatting: false,
   run_after_sync: true,
   daily_note_time_cutoff: "00:00",
+  daily_note_timezone: "",
   insert_after_heading: false,
   target_heading: "## Inbox",
   action_after_reception: "react",

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,173 @@
+import type { MessageUpdate } from "./type";
+
+const MAX_PROCESSED_MESSAGE_KEYS = 5000;
+const INITIAL_RETRY_DELAY_MS = 60_000;
+const MAX_RETRY_DELAY_MS = 12 * 60 * 60 * 1000;
+
+/**
+ * Persistent retry payload for messages that failed to be written to the vault.
+ * Timestamps are Unix epoch milliseconds.
+ */
+export interface RetryQueueItem {
+  id: string;
+  message_key: string;
+  update_id?: number;
+  msg: MessageUpdate;
+  content: string;
+  attempts: number;
+  created_at: number;
+  next_retry_at: number;
+  last_error: string;
+}
+
+/**
+ * Runtime state stored alongside plugin settings.
+ *
+ * - `last_processed_update_id` protects polling offsets across restarts.
+ * - `processed_message_keys` is a bounded in-memory/persisted dedupe set.
+ * - `retry_queue` holds failed writes for manual or automatic retries.
+ */
+export interface TGInboxRuntimeState {
+  last_processed_update_id: number;
+  processed_message_keys: string[];
+  retry_queue: RetryQueueItem[];
+}
+
+export const DEFAULT_RUNTIME_STATE: TGInboxRuntimeState = {
+  last_processed_update_id: 0,
+  processed_message_keys: [],
+  retry_queue: [],
+};
+
+/**
+ * High-level state API that centralizes dedupe, retry queue, and persistence.
+ * Keeping these behaviors in one place avoids inconsistencies in handlers.
+ */
+export class RuntimeStateStore {
+  constructor(
+    private state: TGInboxRuntimeState,
+    private persist: () => Promise<void>
+  ) {}
+
+  /** Returns the highest update id that has been successfully persisted. */
+  getLastProcessedUpdateId(): number {
+    return this.state.last_processed_update_id;
+  }
+
+  /** Builds a stable dedupe key from Telegram chat id and message id. */
+  buildMessageKey(msg: MessageUpdate): string {
+    return `${msg.chat.id}:${msg.message_id}`;
+  }
+
+  /** Checks whether a message key was already persisted before. */
+  hasProcessed(messageKey: string): boolean {
+    return this.state.processed_message_keys.includes(messageKey);
+  }
+
+  /**
+   * Marks a message as processed and updates offset tracking.
+   * Also removes any pending retry item for the same message key.
+   */
+  async markProcessed(messageKey: string, updateId?: number): Promise<void> {
+    if (!this.hasProcessed(messageKey)) {
+      this.state.processed_message_keys.push(messageKey);
+      this.trimProcessedMessageKeys();
+    }
+
+    if (updateId && updateId > this.state.last_processed_update_id) {
+      this.state.last_processed_update_id = updateId;
+    }
+
+    this.removeRetryByMessageKey(messageKey);
+    await this.persist();
+  }
+
+  /** Returns queue items that are ready to run at `now`. */
+  getReadyRetries(now = Date.now()): RetryQueueItem[] {
+    return this.state.retry_queue.filter((item) => item.next_retry_at <= now);
+  }
+
+  /**
+   * Adds or refreshes a retry queue item for a message write failure.
+   * Existing items keep their attempt counters and retry windows.
+   */
+  async enqueueRetry(params: {
+    messageKey: string;
+    updateId?: number;
+    msg: MessageUpdate;
+    content: string;
+    error: string;
+  }): Promise<void> {
+    const existingItem = this.state.retry_queue.find(
+      (item) => item.message_key === params.messageKey
+    );
+
+    if (existingItem) {
+      existingItem.last_error = params.error;
+      await this.persist();
+      return;
+    }
+
+    this.state.retry_queue.push({
+      id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      message_key: params.messageKey,
+      update_id: params.updateId,
+      msg: params.msg,
+      content: params.content,
+      attempts: 0,
+      created_at: Date.now(),
+      next_retry_at: Date.now() + INITIAL_RETRY_DELAY_MS,
+      last_error: params.error,
+    });
+
+    await this.persist();
+  }
+
+  /**
+   * Records a failed retry attempt using exponential backoff with a max cap.
+   */
+  async markRetryAttemptFailure(id: string, error: string): Promise<void> {
+    const item = this.state.retry_queue.find((retryItem) => retryItem.id === id);
+    if (!item) {
+      return;
+    }
+
+    item.attempts += 1;
+    item.last_error = error;
+    const delay = Math.min(
+      INITIAL_RETRY_DELAY_MS * 2 ** item.attempts,
+      MAX_RETRY_DELAY_MS
+    );
+    item.next_retry_at = Date.now() + delay;
+    await this.persist();
+  }
+
+  /** Clears all queued retry entries. */
+  async clearRetryQueue(): Promise<void> {
+    if (this.state.retry_queue.length === 0) {
+      return;
+    }
+    this.state.retry_queue = [];
+    await this.persist();
+  }
+
+  /** Returns pending retry item count. */
+  getRetryQueueSize(): number {
+    return this.state.retry_queue.length;
+  }
+
+  private removeRetryByMessageKey(messageKey: string): void {
+    this.state.retry_queue = this.state.retry_queue.filter(
+      (item) => item.message_key !== messageKey
+    );
+  }
+
+  private trimProcessedMessageKeys(): void {
+    if (this.state.processed_message_keys.length <= MAX_PROCESSED_MESSAGE_KEYS) {
+      return;
+    }
+    this.state.processed_message_keys = this.state.processed_message_keys.slice(
+      -MAX_PROCESSED_MESSAGE_KEYS
+    );
+  }
+}

--- a/src/utils/diary.ts
+++ b/src/utils/diary.ts
@@ -8,13 +8,18 @@ import type { TGInboxSettings } from "../settings/types";
 
 const DEFAULT_CUTOFF = "00:00";
 
+/**
+ * Resolves the daily note file after applying timezone + cutoff rules.
+ * Creates the target daily note when it does not exist.
+ */
 export async function getDiaryWithTimeCutoff(
   settings: TGInboxSettings,
   messageDate?: moment.Moment
 ) {
   const date = messageDate || moment();
+  const zonedDate = applyTimezone(date, settings.daily_note_timezone);
   const adjustedDate = getAdjustedDateForTimeCutoff(
-    date,
+    zonedDate,
     settings.daily_note_time_cutoff || DEFAULT_CUTOFF
   );
 
@@ -29,6 +34,10 @@ export async function getDiaryWithTimeCutoff(
   return await createDailyNote(adjustedDate);
 }
 
+/**
+ * Shifts messages before cutoff to the previous day.
+ * Example: cutoff "04:00" means 03:59 belongs to yesterday.
+ */
 export function getAdjustedDateForTimeCutoff(
   messageDate: moment.Moment,
   timeCutoff: string
@@ -46,4 +55,49 @@ export function getAdjustedDateForTimeCutoff(
   }
 
   return moment(messageDate);
+}
+
+/**
+ * Applies an IANA timezone by reconstructing a local moment from formatted parts.
+ * If timezone is blank or invalid, system timezone is used.
+ */
+function applyTimezone(date: moment.Moment, timezone: string): moment.Moment {
+  const normalizedTimezone = timezone.trim();
+  if (!normalizedTimezone) {
+    return moment(date);
+  }
+
+  try {
+    const formatter = new Intl.DateTimeFormat("en-CA", {
+      timeZone: normalizedTimezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hourCycle: "h23",
+    });
+
+    const parts = formatter.formatToParts(date.toDate());
+    const year = getPart(parts, "year");
+    const month = getPart(parts, "month");
+    const day = getPart(parts, "day");
+    const hour = getPart(parts, "hour");
+    const minute = getPart(parts, "minute");
+    const second = getPart(parts, "second");
+
+    return moment(`${year}-${month}-${day}T${hour}:${minute}:${second}`);
+  } catch (error) {
+    console.warn(`Invalid timezone '${normalizedTimezone}', using system timezone.`, error);
+    return moment(date);
+  }
+}
+
+/** Reads a specific part from Intl formatted output with zero fallback. */
+function getPart(
+  parts: Intl.DateTimeFormatPart[],
+  type: Intl.DateTimeFormatPartTypes
+): string {
+  return parts.find((part) => part.type === type)?.value ?? "00";
 }

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -46,7 +46,7 @@ export function buildMsgData(
   setting: TGInboxSettings
 ): MessageData {
   const forwardOrigin = getForwardOrigin(msg);
-  const msgDate = moment(msg.date * 1000);
+  const msgDate = getMessageDateForTimezone(msg.date, setting.daily_note_timezone);
 
   return {
     message_id: msg.message_id,
@@ -64,7 +64,7 @@ export function generatePath(
   msg: MessageUpdate,
   setting: TGInboxSettings
 ): string {
-  const data = sanitizePathData(buildPathData(msg));
+  const data = sanitizePathData(buildPathData(msg, setting.daily_note_timezone));
   return Mustache.render(setting.custom_file_path, data);
 }
 
@@ -77,8 +77,8 @@ function sanitizePathData(data: PathData): PathData {
   };
 }
 
-export function buildPathData(msg: MessageUpdate): PathData {
-  const msgDate = moment(msg.date * 1000);
+export function buildPathData(msg: MessageUpdate, timezone = ""): PathData {
+  const msgDate = getMessageDateForTimezone(msg.date, timezone);
   const forwardOrigin = getForwardOrigin(msg);
 
   return {
@@ -89,6 +89,52 @@ export function buildPathData(msg: MessageUpdate): PathData {
     user_id: msg.from?.id ?? msg.chat.id,
     origin_name: forwardOrigin?.origin_name ?? getSenderName(msg),
   };
+}
+
+function getMessageDateForTimezone(
+  unixSeconds: number,
+  timezone: string
+): moment.Moment {
+  const date = moment(unixSeconds * 1000);
+  const normalizedTimezone = timezone.trim();
+  if (!normalizedTimezone) {
+    return date;
+  }
+
+  try {
+    const formatter = new Intl.DateTimeFormat("en-CA", {
+      timeZone: normalizedTimezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hourCycle: "h23",
+    });
+    const parts = formatter.formatToParts(date.toDate());
+    const year = getPart(parts, "year");
+    const month = getPart(parts, "month");
+    const day = getPart(parts, "day");
+    const hour = getPart(parts, "hour");
+    const minute = getPart(parts, "minute");
+    const second = getPart(parts, "second");
+
+    return moment(`${year}-${month}-${day}T${hour}:${minute}:${second}`);
+  } catch (error) {
+    console.warn(
+      `Invalid timezone '${normalizedTimezone}' for message formatting, using system timezone.`,
+      error
+    );
+    return date;
+  }
+}
+
+function getPart(
+  parts: Intl.DateTimeFormatPart[],
+  type: Intl.DateTimeFormatPartTypes
+): string {
+  return parts.find((part) => part.type === type)?.value ?? "00";
 }
 
 interface ForwardOriginInfo {

--- a/test/buildData.spec.ts
+++ b/test/buildData.spec.ts
@@ -10,6 +10,11 @@ const settings: TGInboxSettings = {
     allow_users: [],
     download_dir: "",
     download_media: false,
+    media_filter_voice: true,
+    media_filter_audio: true,
+    media_filter_photo: true,
+    media_filter_video: true,
+    media_filter_document: true,
     message_template: "",
     markdown_escaper: false,
     is_custom_file: false,
@@ -18,6 +23,10 @@ const settings: TGInboxSettings = {
     reverse_order: false,
     remove_formatting: false,
     daily_note_time_cutoff: "00:00",
+    daily_note_timezone: "Asia/Shanghai",
+    insert_after_heading: false,
+    target_heading: "## Inbox",
+    action_after_reception: "react",
     run_after_sync: false,
 }
 

--- a/test/buildPathData.spec.ts
+++ b/test/buildPathData.spec.ts
@@ -3,6 +3,8 @@ import { describe, test } from "node:test";
 import { type PathData, buildPathData } from "../src/utils/template";
 import { msg, msgFowardUser, channel_post, channel_post_fw } from "./msgs";
 
+const timezone = "Asia/Shanghai";
+
 describe('generatePath', () => {
     test('normal message', () => {
         const data: PathData = {
@@ -14,7 +16,7 @@ describe('generatePath', () => {
             origin_name: "Neko ✨"
         }
 
-        assert.deepStrictEqual(buildPathData(msg), data)
+        assert.deepStrictEqual(buildPathData(msg, timezone), data)
     })
 
     test('forward message', () => {
@@ -28,7 +30,7 @@ describe('generatePath', () => {
             origin_name: "猫"
         }
 
-        assert.deepStrictEqual(buildPathData(msgFowardUser), data)
+        assert.deepStrictEqual(buildPathData(msgFowardUser, timezone), data)
     })
 
     test('channel post', () => {
@@ -40,7 +42,7 @@ describe('generatePath', () => {
             user_id: -1001234567890,
             origin_name: "📒"
         }
-        assert.deepStrictEqual(buildPathData(channel_post), data)
+        assert.deepStrictEqual(buildPathData(channel_post, timezone), data)
     })
 
     test('channel post forward', () => {
@@ -52,6 +54,6 @@ describe('generatePath', () => {
             user_id: -1001234567890,
             origin_name: "Haha"
         }
-        assert.deepStrictEqual(buildPathData(channel_post_fw), data)
+        assert.deepStrictEqual(buildPathData(channel_post_fw, timezone), data)
     })
 })

--- a/test/generatePath.spec.ts
+++ b/test/generatePath.spec.ts
@@ -18,6 +18,7 @@ const settings: TGInboxSettings = {
     reverse_order: false,
     remove_formatting: false,
     daily_note_time_cutoff: "00:00",
+    daily_note_timezone: "Asia/Shanghai",
     run_after_sync: false
 }
 

--- a/test/state.spec.ts
+++ b/test/state.spec.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { DEFAULT_RUNTIME_STATE, RuntimeStateStore } from "../src/state";
+import type { MessageUpdate } from "../src/type";
+
+function createMessage(chatId: number, messageId: number): MessageUpdate {
+  return {
+    message_id: messageId,
+    from: {
+      id: 123,
+      is_bot: false,
+      first_name: "Test",
+    },
+    chat: {
+      id: chatId,
+      first_name: "Test",
+      type: "private",
+    },
+    date: 1710000000,
+    text: "hello",
+  } as MessageUpdate;
+}
+
+function createStore() {
+  const state = structuredClone(DEFAULT_RUNTIME_STATE);
+  let persistCalls = 0;
+  const store = new RuntimeStateStore(state, async () => {
+    persistCalls += 1;
+  });
+  return { state, store, getPersistCalls: () => persistCalls };
+}
+
+describe("RuntimeStateStore", () => {
+  test("builds stable message key", () => {
+    const { store } = createStore();
+    const key = store.buildMessageKey(createMessage(42, 99));
+    assert.strictEqual(key, "42:99");
+  });
+
+  test("marks message processed and updates update id", async () => {
+    const { state, store, getPersistCalls } = createStore();
+    const key = store.buildMessageKey(createMessage(10, 55));
+
+    await store.markProcessed(key, 777);
+
+    assert.equal(store.hasProcessed(key), true);
+    assert.equal(state.last_processed_update_id, 777);
+    assert.equal(getPersistCalls(), 1);
+  });
+
+  test("removes retry entry once message is processed", async () => {
+    const { state, store } = createStore();
+    const msg = createMessage(5, 6);
+    const key = store.buildMessageKey(msg);
+
+    await store.enqueueRetry({
+      messageKey: key,
+      updateId: 200,
+      msg,
+      content: "hello",
+      error: "write failed",
+    });
+    assert.equal(state.retry_queue.length, 1);
+
+    await store.markProcessed(key, 201);
+
+    assert.equal(state.retry_queue.length, 0);
+    assert.equal(state.last_processed_update_id, 201);
+  });
+
+  test("updates existing retry item instead of duplicating it", async () => {
+    const { state, store } = createStore();
+    const msg = createMessage(7, 8);
+    const key = store.buildMessageKey(msg);
+
+    await store.enqueueRetry({
+      messageKey: key,
+      updateId: 1,
+      msg,
+      content: "a",
+      error: "error A",
+    });
+    await store.enqueueRetry({
+      messageKey: key,
+      updateId: 1,
+      msg,
+      content: "b",
+      error: "error B",
+    });
+
+    assert.equal(state.retry_queue.length, 1);
+    assert.equal(state.retry_queue[0].last_error, "error B");
+    assert.equal(state.retry_queue[0].content, "a");
+  });
+
+  test("returns ready retries by timestamp filter", async () => {
+    const { store } = createStore();
+    const msgA = createMessage(1, 1);
+    const msgB = createMessage(1, 2);
+
+    await store.enqueueRetry({
+      messageKey: store.buildMessageKey(msgA),
+      msg: msgA,
+      content: "a",
+      error: "error",
+    });
+    await store.enqueueRetry({
+      messageKey: store.buildMessageKey(msgB),
+      msg: msgB,
+      content: "b",
+      error: "error",
+    });
+
+    const future = Date.now() + 2 * 60_000;
+    const ready = store.getReadyRetries(future);
+    assert.equal(ready.length, 2);
+  });
+
+  test("caps processed key history at configured size", async () => {
+    const { state, store } = createStore();
+
+    for (let i = 0; i < 5_010; i += 1) {
+      await store.markProcessed(`1:${i}`);
+    }
+
+    assert.equal(state.processed_message_keys.length, 5_000);
+    assert.equal(state.processed_message_keys[0], "1:10");
+    assert.equal(state.processed_message_keys[4_999], "1:5009");
+  });
+});

--- a/test/template-enhanced.spec.ts
+++ b/test/template-enhanced.spec.ts
@@ -23,6 +23,7 @@ const baseSettings: TGInboxSettings = {
   reverse_order: false,
   remove_formatting: false,
   daily_note_time_cutoff: "00:00",
+  daily_note_timezone: "Asia/Shanghai",
   run_after_sync: false,
 };
 
@@ -217,7 +218,7 @@ describe("generatePath", () => {
 describe("buildPathData", () => {
   test("builds path data for normal message", () => {
     const msg = createMockMessage("Test");
-    const result = buildPathData(msg);
+    const result = buildPathData(msg, baseSettings.daily_note_timezone);
     assert.deepStrictEqual(result, {
       date: "2021-07-21",
       first_name: "Test",
@@ -237,7 +238,7 @@ describe("buildPathData", () => {
         username: "testuser",
       },
     });
-    const result = buildPathData(msg);
+    const result = buildPathData(msg, baseSettings.daily_note_timezone);
     assert.deepStrictEqual(result, {
       date: "2021-07-21",
       first_name: "Test",
@@ -262,7 +263,7 @@ describe("buildPathData", () => {
         date: 1626847200,
       },
     });
-    const result = buildPathData(msg);
+    const result = buildPathData(msg, baseSettings.daily_note_timezone);
     assert.deepStrictEqual(result, {
       date: "2021-07-21",
       first_name: "Test",
@@ -291,7 +292,7 @@ describe("buildPathData", () => {
       date: 1626847200,
       text: "Channel message",
     } as MessageUpdate;
-    const result = buildPathData(msg);
+    const result = buildPathData(msg, baseSettings.daily_note_timezone);
     assert.deepStrictEqual(result, {
       date: "2021-07-21",
       first_name: "📒 Channel",
@@ -306,7 +307,7 @@ describe("buildPathData", () => {
     const morningMsg = createMockMessage("Morning", {
       date: 1626843600, // 2021-07-21 13:00:00
     });
-    const result = buildPathData(morningMsg);
+    const result = buildPathData(morningMsg, baseSettings.daily_note_timezone);
     assert.strictEqual(result.time, "13-00");
   });
 
@@ -319,8 +320,8 @@ describe("buildPathData", () => {
       date: 1626847200, // Original timestamp
     });
     
-    const morningResult = buildPathData(morningMsg);
-    const afternoonResult = buildPathData(afternoonMsg);
+    const morningResult = buildPathData(morningMsg, baseSettings.daily_note_timezone);
+    const afternoonResult = buildPathData(afternoonMsg, baseSettings.daily_note_timezone);
     
     // Times should be different
     assert.notStrictEqual(morningResult.time, afternoonResult.time);


### PR DESCRIPTION
# **Summary**

Add persistent deduplication and retry handling, introduces quiet mode/media filters/timezone-aware cutoff, and simplify local testing with a single env-driven build+deploy command.

# **Impact**

- Prevents duplicate note entries across restarts/manual update pulls.
- Queues failed writes and enables retries instead of silently losing messages.
- Better message handling controls:
  - Adds quiet action mode (no reaction/delete side effects).
  - Adds per-media-type filters (voice/audio/photo/video/document).
- More accurate daily-note routing:
  - Applies cutoff using configurable timezone. It was set on GMT+8
- Cleaner local/dev workflow
  - One command (npm run deploy:dev) now builds and deploys.
  - Vault path moved to .env (with .env.example) for modular setup.